### PR TITLE
manifest: use https for GitHub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ http://source.android.com/source/downloading.html#installing-repo
 
 	mkdir ~/jtk1-android-l-open-source
 	cd ~/jtk1-android-l-open-source
-	repo init -u git@github.com:NVIDIA/android-manifest.git -b jtk1-android-l -m jtk1_android.xml
+	repo init -u https://github.com/NVIDIA/android-manifest.git -b jtk1-android-l -m jtk1_android.xml
 	repo sync -j5
 
 

--- a/jtk1_android.xml
+++ b/jtk1_android.xml
@@ -7,7 +7,7 @@
 
   <remote  name="nvidia"
            revision="jtk1-android-l"
-           fetch=".." />
+           fetch="https://github.com/NVIDIA" />
 
   <default revision="rel-st8-l-r3-partner"
            remote="nvidia_st8_oss" />


### PR DESCRIPTION
  This is the recommended method for fetching/syncing from GitHub
  so credential.helper is able to cache your password (if available).
  In addition https allows for anonymous pull, which ssh via github
  does not - cloning the repo requires a github account. SSH can
  also cause serious issues when trying to sync multiple GitHub repos
  via `repo sync`.

  - https://help.github.com/articles/which-remote-url-should-i-use/
  - https://gist.github.com/grawity/4392747